### PR TITLE
Build a local Docker image from the source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ You can connect to the console of a local node typing the following:
 docker exec -it antidote /opt/antidote/bin/env attach
 ```
 
+### Building Antidote locally from the source code
+Please look at the [dedicated README doc](https://github.com/AntidoteDB/docker-antidote/tree/master/local-build)
+
 ## Quick reference
 
 - **AntidoteDB**: [Official website][AntidoteDB-website], [Quick start guide](https://antidotedb.gitbook.io/documentation/) or [The AntidoteDB Community Slack](https://antidotedb.slack.com/).

--- a/local-build/Dockerfile
+++ b/local-build/Dockerfile
@@ -1,0 +1,48 @@
+FROM erlang:21
+
+LABEL maintainer="ilyas@toumlilt.com"
+
+ENV HANDOFF_PORT "8099"
+ENV PB_PORT "8087"
+ENV PB_IP "0.0.0.0"
+ENV PBSUB_PORT "8086"
+ENV LOGREADER_PORT "8085"
+ENV RING_STATE_DIR "data/ring"
+ENV PLATFORM_DATA_DIR "data"
+ENV NODE_NAME "antidote@127.0.0.1"
+ENV SHORT_NAME "false"
+
+ENV SRC_SCRIPTS_DIR "./Dockerfiles"
+ENV ANTIDOTE_BUILD_DIR "/usr/src/antidote"
+ENV ANTIDOTE_RUNTIME_DIR "/opt"
+
+COPY . $ANTIDOTE_BUILD_DIR
+
+RUN set -xe \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends git openssl ca-certificates \
+    && cd $ANTIDOTE_BUILD_DIR \
+    && make rel \
+    && cp -R ${ANTIDOTE_BUILD_DIR}/_build/default/rel/antidote $ANTIDOTE_RUNTIME_DIR/ \
+    && sed -e '$i,{kernel, [{inet_dist_listen_min, 9100}, {inet_dist_listen_max, 9100}]}' ${ANTIDOTE_BUILD_DIR}/_build/default/rel/antidote/releases/0.0.2/sys.config > ${ANTIDOTE_RUNTIME_DIR}/antidote/releases/0.0.2/sys.config \
+    && rm -rf ${ANTIDOTE_BUILD_DIR} /var/lib/apt/lists/*
+
+ADD ${SRC_SCRIPTS_DIR}/start_and_attach.sh ${ANTIDOTE_RUNTIME_DIR}/antidote/
+ADD ${SRC_SCRIPTS_DIR}/entrypoint.sh /
+
+RUN chmod a+x ${ANTIDOTE_RUNTIME_DIR}/antidote/start_and_attach.sh \
+    && chmod a+x /entrypoint.sh
+
+# Distributed Erlang Port Mapper
+EXPOSE 4369
+# Ports for Antidote
+EXPOSE 8085 8086 8087 8099
+
+# Antidote RPC
+EXPOSE 9100
+
+VOLUME ${ANTIDOTE_RUNTIME_DIR}/antidote/data
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["sh", "-c", "${ANTIDOTE_RUNTIME_DIR}/antidote/start_and_attach.sh"]

--- a/local-build/README.md
+++ b/local-build/README.md
@@ -1,0 +1,49 @@
+# Build AntidoteDB locally using Docker
+
+The Dockerfile contained in this directory is used to build local AntidoteDB images from the source code, mainly made for dev reasons.
+If you want to use AntidoteDB in production or if you need a stable Docker image, please pull Antidote Docker images from [the official Docker Hub](https://cloud.docker.com/u/antidotedb/repository/docker/antidotedb/antidote), or use Dockerfiles from its [Github source repository](https://github.com/AntidoteDB/docker-antidote).
+
+# Getting started
+
+## Prerequisites
+
+- Working recent version of Docker (1.12 and up recommended)
+
+## Building the image locally
+
+For building the Docker image on your local machine, use the following command (must be executed from the antidote.git root directory)
+```
+tmpdir=`mktemp -d` 
+wget "https://raw.githubusercontent.com/AntidoteDB/docker-antidote/master/local-build/Dockerfile" -O "$$tmpdir/Dockerfile"
+wget "https://raw.githubusercontent.com/AntidoteDB/docker-antidote/master/local-build/entrypoint.sh" -O "$$tmpdir/entrypoint.sh"
+wget "https://raw.githubusercontent.com/AntidoteDB/docker-antidote/master/local-build/start_and_attach.sh" -O "$$tmpdir/start_and_attach.sh"
+cd $$tmpdir
+docker build -f Dockerfile -t antidotedb:local-build .
+```
+
+or simply 
+```
+make docker-build
+```
+
+Then you can run it using:
+```
+docker run -d --name antidote -p "8087:8087" antidotedb:local-build
+```
+or:
+```
+make docker-run
+```
+
+## Using the local node
+
+Wait until Antidote is ready. The current log can be inspected with `docker logs antidote`. Wait until the log message `Application antidote started on node 'antidote@127.0.0.1'` appears.
+
+Antidote should now be running on port 8087 on localhost.
+
+## Connect to the console
+
+You can connect to the console of a local node typing the following:
+```
+docker exec -it antidote /opt/antidote/bin/env attach
+```

--- a/local-build/entrypoint.sh
+++ b/local-build/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+if [[ ! -f /opt/antidote/releases/0.0.2/setup_ok ]]; then
+  cd /opt/antidote/releases/0.0.2/
+  cp vm.args vm.args_backup
+  if [[ "$SHORT_NAME" = "true" ]]; then
+    sed "s/-name /-sname /" vm.args_backup > vm.args
+  fi
+  touch setup_ok
+fi
+
+exec "$@"

--- a/local-build/start_and_attach.sh
+++ b/local-build/start_and_attach.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+NPROC=$(nproc)
+
+if [[ ${NPROC} -ge 2 ]]; then
+  trap "echo 'Shutting down' && /opt/antidote/bin/env stop" TERM
+  /opt/antidote/bin/env start &
+
+  echo -n "Waiting for Antidote logger..."
+  while [ ! -f /opt/antidote/log/console.log ]
+  do
+	  sleep 1
+  done
+  echo "✔"
+
+  tail -F /opt/antidote/log/console.log &
+  wait ${!}
+
+else
+  echo "You need at least 2 cpu cores in your Docker (virtual) machine to run this image!"
+  echo "You have ${NPROC} processors"
+  exit 1
+fi


### PR DESCRIPTION
- For dev reasons we still need a way to build a local image from the source code
- (portability) when benchmarking it's easier to build this image without worrying about dependencies